### PR TITLE
fix: only use hm cachix when not using global packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Cache 📝](https://github.com/dlubawy/nix-configs/actions/workflows/cache.yaml/badge.svg)](https://github.com/dlubawy/nix-configs/actions/workflows/cache.yaml)
+[![Update ⬆️](https://github.com/dlubawy/nix-configs/actions/workflows/update.yaml/badge.svg)](https://github.com/dlubawy/nix-configs/actions/workflows/update.yaml)
+
 # nix-configs
 
 My personal Nix configurations.

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -48,8 +48,8 @@ in
       };
       settings = {
         experimental-features = "nix-command flakes";
-        substituters = outputs.nixConfig.extra-substituters;
-        trusted-public-keys = outputs.nixConfig.extra-trusted-public-keys;
+        substituters = lib.mkIf (!useGlobalPkgs) outputs.nixConfig.extra-substituters;
+        trusted-public-keys = lib.mkIf (!useGlobalPkgs) outputs.nixConfig.extra-trusted-public-keys;
       };
     };
 


### PR DESCRIPTION
* Adds workflow badges
* Don't use cachix in home-manager when using global packages