### PR TITLE
fix: pre-commit input needs nixpkgs-unstable and trufflehog patched

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -117,8 +117,8 @@ in
     optimise.automatic = true;
     settings = {
       experimental-features = "nix-command flakes";
-      substituters = outputs.nixConfig.extra-substituters;
-      trusted-public-keys = outputs.nixConfig.extra-trusted-public-keys;
+      substituters = vars.extra-substituters;
+      trusted-public-keys = vars.extra-trusted-public-keys;
       trusted-users = [
         "root"
         "@admin"

--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -117,8 +117,8 @@ in
     optimise.automatic = true;
     settings = {
       experimental-features = "nix-command flakes";
-      substituters = vars.extra-substituters;
-      trusted-public-keys = vars.extra-trusted-public-keys;
+      substituters = vars.nixConfig.extra-substituters;
+      trusted-public-keys = vars.nixConfig.extra-trusted-public-keys;
       trusted-users = [
         "root"
         "@admin"

--- a/flake.lock
+++ b/flake.lock
@@ -270,11 +270,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747020534,
-        "narHash": "sha256-D/6rkiC6w2p+4SwRiVKrWIeYzun8FBg7NlMKMwQMxO0=",
+        "lastModified": 1744117652,
+        "narHash": "sha256-t7dFCDl4vIOOUMhEZnJF15aAzkpaup9x4ZRGToDFYWI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b4bbdc6fde16fc2051fcde232f6e288cd22007ca",
+        "rev": "b4e98224ad1336751a2ac7493967a4c9f6d9cb3f",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744743431,
-        "narHash": "sha256-iyn/WBYDc7OtjSawbegINDe/gIkok888kQxk3aVnkgg=",
+        "lastModified": 1744117652,
+        "narHash": "sha256-t7dFCDl4vIOOUMhEZnJF15aAzkpaup9x4ZRGToDFYWI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c61bfe3ae692f42ce688b5865fac9e0de58e1387",
+        "rev": "b4e98224ad1336751a2ac7493967a4c9f6d9cb3f",
         "type": "github"
       },
       "original": {
@@ -320,16 +320,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1737371634,
-        "narHash": "sha256-fTVAWzT1UMm1lT+YxHuVPtH+DATrhYfea3B0MxG/cGw=",
+        "lastModified": 1729958008,
+        "narHash": "sha256-EiOq8jF4Z/zQe0QYVc3+qSKxRK//CFHMB84aYrYGwEs=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "a1176e2a10ce745ff8f63e4af124ece8fe0b1648",
+        "rev": "9fd01aad037f345350eab2cd45e1946cc66da4eb",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.0.7",
+        "ref": "v0.0.6",
         "repo": "ixx",
         "type": "github"
       }
@@ -401,11 +401,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747032063,
-        "narHash": "sha256-OPBKGxrvcZRKhe0mvpx9Y6m1fU6vlGMkkl8qruF2CJg=",
+        "lastModified": 1744492897,
+        "narHash": "sha256-qqKO4FOo/vPmNIaRPcLqwfudUlQ29iNdI1IbCZfjmxs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d46405db38e2c05992f5f790bf1dddcaffd5b400",
+        "rev": "86484f6076aac9141df2bfcddbf7dcfce5e0c6bb",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1746690571,
-        "narHash": "sha256-uu/aarBPzJVJoWfdWe6YkIeRAP25uappdzN+tWTQiME=",
+        "lastModified": 1744480121,
+        "narHash": "sha256-Wl4FOpd7VXecJbqWDooBYazSAhXo4qEIltnDHhj/u9c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97f265593a4888d1f4df1d924cf82dceb9fe561a",
+        "rev": "b53e9c9185a405af2dee16b47db2710072bb3419",
         "type": "github"
       },
       "original": {
@@ -438,11 +438,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747012039,
-        "narHash": "sha256-h3reOnw/JSR++L1BwxQS+gmBu9G2i6sqH2XFCaAR6u8=",
+        "lastModified": 1744511435,
+        "narHash": "sha256-GlEF5MWBYUC7rPm5QQzvcI09GPYsFaW78qkIC5RuL0Q=",
         "owner": "bandithedoge",
         "repo": "nixpkgs-firefox-darwin",
-        "rev": "0fa57fa9e826bfd7ad80b20c5721d4e31e24deb8",
+        "rev": "bfc894b1939f6459810e4b02d947609000abed34",
         "type": "github"
       },
       "original": {
@@ -453,11 +453,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {
@@ -482,11 +482,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1745963276,
-        "narHash": "sha256-MpLljx/1dGnBIQlUswaUz/ZeOp44R3ngc1iBf4tyzyc=",
+        "lastModified": 1744461753,
+        "narHash": "sha256-3oO3CwYmZE5P4Hp5XR5WCZbF/rj5+kF0m5sTNTMDYss=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5bef8e43ce16ee704c7b9fa9f48a07ce81c5c05d",
+        "rev": "a22fbed4c4784e6a9761f9a896d31da98c3117b2",
         "type": "github"
       },
       "original": {
@@ -506,11 +506,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745046075,
-        "narHash": "sha256-8v4y6k16Ra/fiecb4DxhsoOGtzLKgKlS+9/XJ9z0T2I=",
+        "lastModified": 1744375525,
+        "narHash": "sha256-/Wf5Ca0DmV+y+qVBDXX8HAfAvSQI6y5oE27dv6t1jXk=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "066afe8643274470f4a294442aadd988356a478f",
+        "rev": "c0e7d3bda11e2cfad692d205d82757078475957a",
         "type": "github"
       },
       "original": {
@@ -524,15 +524,15 @@
         "flake-compat": "flake-compat_3",
         "gitignore": "gitignore_2",
         "nixpkgs": [
-          "nixpkgs-unstable"
+          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1746537231,
-        "narHash": "sha256-Wb2xeSyOsCoTCTj7LOoD6cdKLEROyFAArnYoS+noCWo=",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "fa466640195d38ec97cf0493d6d6882bc4d14969",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {
@@ -595,11 +595,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744961264,
-        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -524,7 +524,7 @@
         "flake-compat": "flake-compat_3",
         "gitignore": "gitignore_2",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@ rec {
     };
     pre-commit-hooks = {
       url = "github:cachix/git-hooks.nix/master";
-      inputs.nixpkgs.follows = "nixpkgs-unstable";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # Overlays
@@ -190,15 +190,6 @@ rec {
               trufflehog = {
                 enable = true;
                 name = "🔒 Security · Detect hardcoded secrets";
-                entry =
-                  # FIXME: https://github.com/cachix/git-hooks.nix/issues/584
-                  let
-                    script = pkgs.writeShellScript "precommit-trufflehog" ''
-                      set -e
-                      ${pkgs.trufflehog}/bin/trufflehog git "file://$(git rev-parse --show-toplevel)" --since-commit HEAD --only-verified --fail --no-update
-                    '';
-                  in
-                  builtins.toString script;
               };
               nixfmt-rfc-style = {
                 enable = true;

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -48,8 +48,8 @@ in
       };
       settings = {
         experimental-features = "nix-command flakes";
-        substituters = lib.mkIf (!useGlobalPkgs) outputs.nixConfig.extra-substituters;
-        trusted-public-keys = lib.mkIf (!useGlobalPkgs) outputs.nixConfig.extra-trusted-public-keys;
+        substituters = lib.mkIf (!useGlobalPkgs) vars.extra-substituters;
+        trusted-public-keys = lib.mkIf (!useGlobalPkgs) vars.extra-trusted-public-keys;
       };
     };
 

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -48,8 +48,8 @@ in
       };
       settings = {
         experimental-features = "nix-command flakes";
-        substituters = lib.mkIf (!useGlobalPkgs) vars.extra-substituters;
-        trusted-public-keys = lib.mkIf (!useGlobalPkgs) vars.extra-trusted-public-keys;
+        substituters = lib.mkIf (!useGlobalPkgs) vars.nixConfig.extra-substituters;
+        trusted-public-keys = lib.mkIf (!useGlobalPkgs) vars.nixConfig.extra-trusted-public-keys;
       };
     };
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -82,8 +82,8 @@
     optimise.automatic = true;
     settings = {
       experimental-features = "nix-command flakes";
-      substituters = vars.extra-substituters;
-      trusted-public-keys = vars.extra-trusted-public-keys;
+      substituters = vars.nixConfig.extra-substituters;
+      trusted-public-keys = vars.nixConfig.extra-trusted-public-keys;
     };
   };
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -82,8 +82,8 @@
     optimise.automatic = true;
     settings = {
       experimental-features = "nix-command flakes";
-      substituters = outputs.nixConfig.extra-substituters;
-      trusted-public-keys = outputs.nixConfig.extra-trusted-public-keys;
+      substituters = vars.extra-substituters;
+      trusted-public-keys = vars.extra-trusted-public-keys;
     };
   };
 


### PR DESCRIPTION
* Issue with nodejs-20 build test failure on MacOS
  * This bypasses that by using nixpkgs-unstable