### PR TITLE
fix: remove xdg.portals from nixos config

### DIFF
--- a/modules/nixos/nixos.nix
+++ b/modules/nixos/nixos.nix
@@ -63,10 +63,6 @@ in
     };
 
     services.userborn.enable = true;
-    xdg.portal = {
-      configPackages = with pkgs; [ xdg-desktop-portal-hyprland ];
-      wlr.enable = true;
-    };
 
     nix = {
       enable = true;


### PR DESCRIPTION
xdg.portals should be unused right now until GUI desktop env is added. Removing in order to get the failing cache build working again.