### PR TITLE
fix: macos check issue

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -289,10 +289,20 @@ rec {
               };
             };
           };
-          nixvimCheck = nixvim.lib."${pkgs.system}".check.mkTestDerivationFromNixvimModule {
-            inherit pkgs;
-            module = import ./modules/nixvim;
-          };
+          nixvimCheck =
+            # FIXME: remove when fixed: https://github.com/nix-community/nixvim/issues/3576
+            let
+              nixvimModule =
+                { ... }:
+                {
+                  imports = [ ./modules/nixvim ];
+                  nixpkgs.overlays = (builtins.attrValues self.overlays);
+                };
+            in
+            (nixvim.lib."${pkgs.system}".check.mkTestDerivationFromNixvimModule {
+              inherit pkgs;
+              module = nixvimModule;
+            });
         }
       );
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -17,6 +17,11 @@
     fuse-ext2 = prev.fuse-ext2.overrideAttrs (_: (import ./fuse-ext2 { inherit prev final; }));
     ntfs3g = prev.ntfs3g.overrideAttrs (_: (import ./ntfs3g { inherit prev final; }));
     hostapd = prev.hostapd.overrideAttrs (_: (import ./hostapd { inherit prev final; }));
+    vimPlugins = prev.vimPlugins // {
+      CopilotChat-nvim = prev.vimPlugins.CopilotChat-nvim.overrideAttrs (_: {
+        nvimSkipModules = [ "CopilotChat.integrations.fzflua" ];
+      });
+    };
   };
 
   # When applied, the unstable nixpkgs set (declared in the flake inputs) will


### PR DESCRIPTION
Temporary fix for macos check failures. Possibly related to nix-community/nixvim/issues/3576.