### PR TITLE
fix: revert systemd update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1754091436,
+        "narHash": "sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "67df8c627c2c39c41dbec76a1f201929929ab0bd",
         "type": "github"
       },
       "original": {
@@ -264,11 +264,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756679287,
-        "narHash": "sha256-Xd1vOeY9ccDf5VtVK12yM0FS6qqvfUop8UQlxEB+gTQ=",
+        "lastModified": 1755776884,
+        "narHash": "sha256-CPM7zm6csUx7vSfKvzMDIjepEJv1u/usmaT7zydzbuI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07fc025fe10487dd80f2ec694f1cd790e752d0e8",
+        "rev": "4fb695d10890e9fc6a19deadf85ff79ffb78da86",
         "type": "github"
       },
       "original": {
@@ -292,16 +292,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1754860581,
-        "narHash": "sha256-EM0IE63OHxXCOpDHXaTyHIOk2cNvMCGPqLt/IdtVxgk=",
+        "lastModified": 1748294338,
+        "narHash": "sha256-FVO01jdmUNArzBS7NmaktLdGA5qA3lUMJ4B7a05Iynw=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "babfe85a876162c4acc9ab6fb4483df88fa1f281",
+        "rev": "cc5f390f7caf265461d4aab37e98d2292ebbdb85",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.1.1",
+        "ref": "v0.0.8",
         "repo": "ixx",
         "type": "github"
       }
@@ -359,11 +359,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757408761,
-        "narHash": "sha256-V9+Bg4cI7/HGgecybnG75DsZTFazcC9sYHXaUtKg3GE=",
+        "lastModified": 1755261139,
+        "narHash": "sha256-dNaZyiXG7ttAOl5pmA+XMzYFDOGTGqSYZzS+mr/U2QY=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "0d338af7b9a0a2e43b158a925180afeb80178a8b",
+        "rev": "0a8ee26f446de4fa44cecd39bed1229dd9cebb82",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757632301,
-        "narHash": "sha256-5q2Cw5/3EB86h9vm/GKhHQWNPddfpZsS7CXS3zTUusU=",
+        "lastModified": 1755816763,
+        "narHash": "sha256-N5TgovVhTlwdh19T9N/mVbaxYtYqxGOv6Td3/KzoY+c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "639f5e5962c6935a7255d0ca9583fc44cfe95307",
+        "rev": "a1e091a68a23fbe05c54119f0e50a84cb187a22a",
         "type": "github"
       },
       "original": {
@@ -391,11 +391,11 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1757590060,
-        "narHash": "sha256-EWwwdKLMZALkgHFyKW7rmyhxECO74+N+ZO5xTDnY/5c=",
+        "lastModified": 1755736199,
+        "narHash": "sha256-EP24GtYxPHLcTZNQjyXllR/zJ8unzgt4Vt8I+h8mhWo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ef228213045d2cdb5a169a95d63ded38670b293",
+        "rev": "d5c9d443fbdb6e6ac4ad3b0559a672583e1aaf47",
         "type": "github"
       },
       "original": {
@@ -407,11 +407,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1757487488,
-        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1757442216,
-        "narHash": "sha256-OF7qMg9dzgcyPcw1ohI8zCUnXSSM0yS6ab74R4ViTKY=",
+        "lastModified": 1755727480,
+        "narHash": "sha256-eb9N7XFj1zirk+D2KV+rn/CjmVHDISlxhtZCWZEVpkM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "af51ab6dceb2881593d63d5d101bdcb02bbd5ea1",
+        "rev": "6df0b97b39baa1c0b3002b051f307aed68e17d1b",
         "type": "github"
       },
       "original": {
@@ -455,11 +455,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756738487,
-        "narHash": "sha256-8QX7Ab5CcICp7zktL47VQVS+QeaU4YDNAjzty7l7TQE=",
+        "lastModified": 1753771532,
+        "narHash": "sha256-Pmpke0JtLRzgdlwDC5a+aiLVZ11JPUO5Bcqkj0nHE/k=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "5feeaeefb571e6ca2700888b944f436f7c05149b",
+        "rev": "2a65adaf2c0c428efb0f4a2bc406aab466e96a06",
         "type": "github"
       },
       "original": {

--- a/hosts/bpi/default.nix
+++ b/hosts/bpi/default.nix
@@ -41,6 +41,14 @@ in
     system.etc.overlay.enable = lib.mkForce false;
     systemd.sysusers.enable = lib.mkForce false;
 
+    # FIXME: ISSUE[#91] remove when systemd v257.9 is backported
+    system = {
+      autoUpgrade = {
+        enable = lib.mkForce false;
+        allowReboot = lib.mkForce false;
+      };
+    };
+
     # FIXME: System seems unstable after 24h uptime so let's reboot everyday
     systemd.timers = {
       "scheduled-reboot" = {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -25,16 +25,6 @@
         nvimSkipModules = [ "render-markdown.config.patterns" ];
       });
     };
-    # FIXME: ISSUE[#91] remove when v257.9 is backported
-    systemd = prev.systemd.overrideAttrs (_: rec {
-      version = "257.7";
-      src = prev.pkgs.fetchFromGitHub {
-        owner = "systemd";
-        repo = "systemd";
-        rev = "v${version}";
-        hash = "sha256-9OnjeMrfV5DSAoX/aetI4r/QLPYITUd2aOY0DYfkTzQ=";
-      };
-    });
   };
 
   # When applied, the unstable nixpkgs set (declared in the flake inputs) will

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -25,6 +25,16 @@
         nvimSkipModules = [ "render-markdown.config.patterns" ];
       });
     };
+    # FIXME: ISSUE[#91] remove when v257.9 is backported
+    systemd = prev.systemd.overrideAttrs (_: rec {
+      version = "257.7";
+      src = prev.pkgs.fetchFromGitHub {
+        owner = "systemd";
+        repo = "systemd";
+        rev = "v${version}";
+        hash = "sha256-9OnjeMrfV5DSAoX/aetI4r/QLPYITUd2aOY0DYfkTzQ=";
+      };
+    });
   };
 
   # When applied, the unstable nixpkgs set (declared in the flake inputs) will


### PR DESCRIPTION
- Turns off automatic updates on bpi
- Rollback `flake.lock` until update gets pulled from bpi

Issues:
- #91 (complete task 1)

Steps after merge:
- [ ] Build cache
- [ ] Update bpi with updates turned off
- [ ] Run flake update to push latest changes for other systems