### PR TITLE
fix: initial user shadow file modes and attrs

### DIFF
--- a/modules/nixos/users.nix
+++ b/modules/nixos/users.nix
@@ -65,10 +65,13 @@ in
           username: opts:
           nameValuePair ((toString opts.home) + "/.shadow") {
             f = {
-              mode = "0000";
+              mode = "0600";
               user = opts.name;
               inherit (opts) group;
               argument = (getAttr opts.name config.nix-configs.users).initialHashedPassword;
+            };
+            h = {
+              argument = "+i";
             };
           }
         )


### PR DESCRIPTION
- Initial `~/.shadow` file set to mode '0600', the same as `nixos-mkpasswd` output
- Sets immutable through tmpfiles on initial `~/.shadow` file