### PR TITLE
refactor: allow defining darwin system topology separate from module

### DIFF
--- a/hosts/bpi/topology.nix
+++ b/hosts/bpi/topology.nix
@@ -4,11 +4,12 @@
   ...
 }:
 let
+  inherit (config.lib.topology) mkDevice mkInternet mkConnection;
   homeDomain = config.homeDomain;
 in
-with config.lib.topology;
 {
   topology = {
+    enable = true;
     nodes = {
       internet = mkInternet {
         connections = mkConnection "bpi" "sfp2";

--- a/hosts/laplace/default.nix
+++ b/hosts/laplace/default.nix
@@ -1,5 +1,8 @@
 { ... }:
 {
-  imports = [ ../../users ];
+  imports = [
+    ../../users
+    ./topology.nix
+  ];
   systemName = "laplace";
 }

--- a/hosts/laplace/topology.nix
+++ b/hosts/laplace/topology.nix
@@ -1,0 +1,36 @@
+{ config, ... }:
+let
+  inherit (config.lib.topology) mkConnectionRev;
+in
+{
+  topology = {
+    enable = true;
+    self = {
+      info = "MacBook Pro M1";
+      interfaceGroups = [
+        [ "en0" ]
+        [ "utun4" ]
+      ];
+      connections = {
+        utun4 = mkConnectionRev "tailscale" "lan";
+      };
+      icon = "devices.laptop";
+      deviceIcon = "devices.nix-darwin";
+      interfaces = {
+        en0 = {
+          icon = "interfaces.wifi";
+          addresses = [ "dhcp" ];
+          physicalConnections = [
+            (mkConnectionRev "bpi" "wlan0.20")
+            (mkConnectionRev "bpi" "wlan1.20")
+          ];
+        };
+        utun4 = {
+          icon = "interfaces.tailscale";
+          addresses = [ "dhcp" ];
+          virtual = true;
+        };
+      };
+    };
+  };
+}

--- a/modules/darwin/darwin.nix
+++ b/modules/darwin/darwin.nix
@@ -7,15 +7,22 @@
   vars,
   ...
 }:
+let
+  inherit (lib)
+    mkOption
+    types
+    ;
+in
 {
   imports = [
     inputs.nixvim.nixDarwinModules.nixvim
     ./users.nix
+    ./topology.nix
   ];
 
   options = {
-    systemName = lib.mkOption {
-      type = lib.types.str;
+    systemName = mkOption {
+      type = types.str;
       description = "System name for deriving admin username and computer hostname";
     };
   };

--- a/modules/darwin/topology.nix
+++ b/modules/darwin/topology.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  options,
+  inputs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    types
+    mkOption
+    mkDefault
+    ;
+  topologyModule = (import inputs.nix-topology.nixosModules.default { inherit config lib options; });
+  topologyLib = builtins.head (
+    builtins.filter (x: builtins.hasAttr "lib" x) topologyModule.config.contents
+  );
+in
+{
+  options = {
+    topology = {
+      enable = mkEnableOption "Enable system in topology view";
+      self = mkOption {
+        description = "Topology device attributes";
+        type = types.attrs;
+      };
+    };
+  };
+
+  config = {
+    lib.topology = topologyLib.lib.topology;
+    topology.self = mkDefault { };
+  };
+}

--- a/modules/nixos/nixos.nix
+++ b/modules/nixos/nixos.nix
@@ -6,6 +6,7 @@
   ...
 }:
 let
+  inherit (lib) mkEnableOption optionals;
   systemName = config.networking.hostName;
 in
 {
@@ -15,6 +16,10 @@ in
     ./nix.nix
     ./users.nix
   ];
+
+  options = {
+    topology.enable = mkEnableOption "Enable system in topology view";
+  };
 
   config = {
     environment.shellAliases = {


### PR DESCRIPTION
- makes the topology module work more as a module
  - allows darwin host configs to define a topology through `topology = { enable = true; self = { ... }; };`
- moves laplace topology config to its host config