### PR TITLE
fix: nixvim neo-tree setting

### DIFF
--- a/modules/nixvim/default.nix
+++ b/modules/nixvim/default.nix
@@ -121,8 +121,8 @@
     neo-tree = {
       enable = true;
       settings = {
-        closeIfLastWindow = true;
-        filesystem.followCurrentFile.enabled = true;
+        close_if_last_window = true;
+        filesystem.follow_current_file.enabled = true;
       };
     };
     spectre = {


### PR DESCRIPTION
neo-tree setting names were changed. This PR fixes the names so the settings are actually applied.