### PR TITLE
fix: switch default model to gpt-5 mini

### DIFF
--- a/modules/nixvim/plugins/copilot.nix
+++ b/modules/nixvim/plugins/copilot.nix
@@ -14,7 +14,7 @@
     copilot-cmp.enable = true;
     copilot-chat = {
       enable = true;
-      settings.model = "claude-3.5-sonnet";
+      settings.model = "gpt-5-mini";
     };
   };
 }


### PR DESCRIPTION
Claude 3.5 sonnet is deprecated. Switch to GPT-5 mini model for default.