### PR TITLE
fix: tmux prefix binding

### DIFF
--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -6,6 +6,9 @@
       set-option -sa terminal-features ',xterm*:RGB'
       set -gq allow-passthrough on
 
+      # Allows prefix sending when in ssh session
+      bind C-Space send-prefix
+
       bind | split-window -h -c "#{pane_current_path}"
       bind - split-window -v -c "#{pane_current_path}"
       bind c new-window -c "#{pane_current_path}"


### PR DESCRIPTION
An upstream PR broke tmux sending prefix through to an SSH session: https://github.com/nix-community/home-manager/pull/7549

This PR applies a fix to allow SSH sessions to receive the prefix again to control the tmux session on the host system.