### PR TITLE
fix: try enabling bss idle protected frames

### DIFF
--- a/hosts/bpi/hostapd.nix
+++ b/hosts/bpi/hostapd.nix
@@ -143,6 +143,7 @@
 
                 # Roaming
                 bss_transition = 1;
+                ap_max_inactivity = 15;
                 bss_max_idle = 2;
                 ft_over_ds = 0;
                 mobility_domain = "3143";
@@ -157,6 +158,7 @@
                 wnm_sleep_mode = 1;
                 wpa_key_mgmt = lib.mkForce "SAE FT-SAE";
                 rsn_preauth = 1;
+                rsn_preauth_interfaces = "br-lan";
                 okc = 1;
               };
               dynamicConfigScripts = {
@@ -245,8 +247,8 @@
 
                 # Roaming
                 bss_transition = 1;
+                ap_max_inactivity = 15;
                 bss_max_idle = 2;
-                skip_inactivity_poll = 1;
                 ft_over_ds = 0;
                 mobility_domain = "3143";
                 nas_identifier = "daef7a02e13c";
@@ -260,6 +262,7 @@
                 wnm_sleep_mode = 1;
                 wpa_key_mgmt = lib.mkForce "SAE FT-SAE";
                 rsn_preauth = 1;
+                rsn_preauth_interfaces = "br-lan";
                 okc = 1;
               };
               dynamicConfigScripts = {


### PR DESCRIPTION
Macs are still encountering an issue after WiFi wake-up where they are unable to connect to the router in the following flow: Mac connects to 5G AP -> Mac WiFi enters sleep mode -> Mac WiFi awakens and attempts to connect to 2.4G AP -> 2.4G connection drops as the AP is still associated on the 5G AP and hasn't transitioned properly. I want to explore different options now since the PMKSA cache now works and can be ruled out as the issue behind this problem.

`ieee80211w=1` and `sae_require_mfp=1` is set, so the hope is that the `bss_max_idle=2` option may fix the issue around how the connection is being kept alive because there is currently a mismatch in allowing non-protected frames for keep-alive.

If this doesn't work, then the only other options that seem worth trying may be the `ap_max_inactivity` or `skip_inactivity_poll`.