### PR TITLE
fix: remove unnecessary sshd address config

### DIFF
--- a/hosts/bpi/default.nix
+++ b/hosts/bpi/default.nix
@@ -118,18 +118,6 @@ in
     services = {
       openssh = {
         enable = true;
-        listenAddresses = [
-          # Only allow vl-lan SSH on local net
-          {
-            addr = "192.168.1.1";
-            port = 22;
-          }
-          # Allow backup SSH from tailnet on 2222
-          {
-            addr = "100.64.0.1";
-            port = 2222;
-          }
-        ];
         settings = {
           PasswordAuthentication = false;
           KbdInteractiveAuthentication = false;


### PR DESCRIPTION
Error noticed in logs for 2222 being in use already. `listenAddresses` might be unnecessary. Let port 2222 be the only assigned as a tailscale ssh backup.