### PR TITLE
fix: reduce default permissions in update workflow

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,8 +6,7 @@ on:
     - cron: "0 0 * * 5" # runs weekly on Friday at 00:00
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update:
@@ -20,6 +19,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6
         with:


### PR DESCRIPTION
Reduces default permissions of update workflow and only expands permissions with token when needed.