### PR TITLE
fix: remove ap_max_inactivity for breaking some connections

### DIFF
--- a/hosts/bpi/hostapd.nix
+++ b/hosts/bpi/hostapd.nix
@@ -145,7 +145,6 @@
 
                 # Roaming
                 bss_transition = 1;
-                ap_max_inactivity = 15;
                 bss_max_idle = 2;
                 ft_over_ds = 0;
                 mobility_domain = "3143";
@@ -249,7 +248,6 @@
 
                 # Roaming
                 bss_transition = 1;
-                ap_max_inactivity = 15;
                 bss_max_idle = 2;
                 ft_over_ds = 0;
                 mobility_domain = "3143";


### PR DESCRIPTION
`ap_max_inactivity` was breaking some connections on 5G. This PR removes it. Will need to monitor Apple devices because this was originally set to kick them when they didn't disassociate from the previous AP during roaming.