### PR TITLE
fix: SSH_AUTH_SOCK not being set for qtpass

### DIFF
--- a/modules/home-manager/qtpass.nix
+++ b/modules/home-manager/qtpass.nix
@@ -20,12 +20,6 @@ in
         GOPASS_GPG_OPTS = "--no-throw-keyids";
         PASSWORD_STORE_GPG_OPTS = "--no-throw-keyids";
       };
-
-      file."Applications/QtPass.app" = lib.mkIf (pkgs.stdenv.isDarwin) {
-        enable = true;
-        source = "${pkgs.qtpass}/bin/QtPass.app";
-        recursive = true;
-      };
     };
 
     launchd.agents = lib.mkIf (pkgs.stdenv.isDarwin) {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -24,6 +24,25 @@
           };
         });
       };
+
+      qtpass = prev.qtpass.overrideAttrs (_: {
+        qtWrapperArgs = [
+          "--run SSH_AUTH_SOCK=$HOME/.gnupg/S.gpg-agent.ssh"
+          "--set-default SSH_AUTH_SOCK SSH_AUTH_SOCK"
+          "--suffix PATH : ${
+            prev.lib.makeBinPath (
+              builtins.attrValues {
+                inherit (prev)
+                  git
+                  gnupg
+                  pass
+                  pwgen
+                  ;
+              }
+            )
+          }"
+        ];
+      });
     }
     // (
       if prev.stdenv.hostPlatform.isDarwin then


### PR DESCRIPTION
- Removes the manual setting of QtPass app for Darwin (this has been fixed upstream)
- Sets SSH_AUTH_SOCK in the wrapped Qt application (fixes git syncing in the UI when launched from the wrapper)