### PR TITLE
fix: don't autoupgrade pi host

### DIFF
--- a/hosts/pi/default.nix
+++ b/hosts/pi/default.nix
@@ -30,6 +30,9 @@ in
   };
 
   config = {
+    # NOTE: the Pi does not have enough memory to upgrade automatically
+    # TODO: Setup a push automation to update the Pi ISSUE(#293)
+    system.autoUpgrade.enable = lib.mkForce false;
     security.auditd.enable = true;
     swapDevices = [
       {


### PR DESCRIPTION
Remove auto upgrade for the Pi host because this process kills memory and forces core services to get OOMKilled. Need to do #293 after this.