### PR TITLE
fix: adguard dns resolution for tailscale

### DIFF
--- a/hosts/bpi/adguardhome.nix
+++ b/hosts/bpi/adguardhome.nix
@@ -113,6 +113,8 @@ in
           "https://dns.quad9.net/dns-query"
           "tls://dns.quad9.net"
           "[/local/]127.0.0.53:53"
+          "[/ts.net/]100.100.100.100:53"
+          "[/100.in-addr.arpa/]100.100.100.100:53"
         ];
         upstream_mode = "parallel";
         fallback_dns = [


### PR DESCRIPTION
Fixes tailnet host name lookup and reverse look ups on the router. Fixes name association in adguardhome with querying clients.