### PR TITLE
fix: add conflicts to fix memory consumption during maintenance

### DIFF
--- a/hosts/pi/default.nix
+++ b/hosts/pi/default.nix
@@ -30,9 +30,27 @@ in
   };
 
   config = {
-    # NOTE: the Pi does not have enough memory to upgrade automatically
-    # TODO: Setup a push automation to update the Pi ISSUE(#293)
-    system.autoUpgrade.enable = lib.mkForce false;
+    # Conflict services in order to clear up memory for maintenance operations
+    systemd.services = {
+      nixos-upgrade = {
+        conflicts = [
+          "podman-homeassistant.service"
+          "nix-gc.service"
+        ];
+        onSuccess = [ "podman-homeassistant.service" ];
+        onFailure = [ "podman-homeassistant.service" ];
+      };
+      nix-gc = {
+        conflicts = [
+          "podman-homeassistant.service"
+          "nixos-upgrade.service"
+        ];
+        onSuccess = [ "podman-homeassistant.service" ];
+        onFailure = [ "podman-homeassistant.service" ];
+      };
+      # Need bluetooth service to restart when home-assistant does
+      bluetooth.requires = [ "podman-homeassistant.service" ];
+    };
     security.auditd.enable = true;
     swapDevices = [
       {

--- a/hosts/pi/default.nix
+++ b/hosts/pi/default.nix
@@ -30,6 +30,8 @@ in
   };
 
   config = {
+    system.autoUpgrade.dates = "Sat *-*-* 02:00:00";
+    nix.gc.dates = "Sun *-*-* 02:00:00";
     # Conflict services in order to clear up memory for maintenance operations
     systemd.services = {
       nixos-upgrade = {

--- a/hosts/pi/default.nix
+++ b/hosts/pi/default.nix
@@ -49,7 +49,10 @@ in
         onFailure = [ "podman-homeassistant.service" ];
       };
       # Need bluetooth service to restart when home-assistant does
-      bluetooth.requires = [ "podman-homeassistant.service" ];
+      bluetooth = {
+        before = [ "podman-homeassistant.service" ];
+        partOf = [ "podman-homeassistant.service" ];
+      };
     };
     security.auditd.enable = true;
     swapDevices = [

--- a/hosts/pi/default.nix
+++ b/hosts/pi/default.nix
@@ -54,6 +54,7 @@ in
       bluetooth = {
         before = [ "podman-homeassistant.service" ];
         partOf = [ "podman-homeassistant.service" ];
+        wantedBy = [ "podman-homeassistant.service" ];
       };
     };
     security.auditd.enable = true;

--- a/hosts/pi/default.nix
+++ b/hosts/pi/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption types mkForce;
 in
 {
   imports = [
@@ -30,8 +30,8 @@ in
   };
 
   config = {
-    system.autoUpgrade.dates = "Sat *-*-* 02:00:00";
-    nix.gc.dates = "Sun *-*-* 02:00:00";
+    system.autoUpgrade.dates = mkForce "Sat *-*-* 02:00:00";
+    nix.gc.dates = mkForce "Sun *-*-* 02:00:00";
     # Conflict services in order to clear up memory for maintenance operations
     systemd.services = {
       nixos-upgrade = {


### PR DESCRIPTION
- Add conflicts to high memory usage services to prevent overconsumption of memory during maintenance
- Makes bluetooth a part of home assistant container so it restarts when home assistant restarts (otherwise the bluetooth interface has issues and cannot be controlled anymore)
- Add explicit maintenance windows for automations